### PR TITLE
Fix/logger updates/base

### DIFF
--- a/evo/common_ape_rpe.py
+++ b/evo/common_ape_rpe.py
@@ -43,7 +43,7 @@ def load_trajectories(args):
                     "(EuRoC ground truth is in IMU frame).")
         logger.debug(SEP)
         traj_ref = file_interface.read_euroc_csv_trajectory(args.state_gt_csv)
-        traj_est = file_interface.read_tum_trajectory_file(args.est_file)
+        traj_est = file_interface.read_euroc_csv_trajectory(args.est_file)
         ref_name, est_name = args.state_gt_csv, args.est_file
     elif args.subcommand == "bag":
         import rosbag

--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -187,7 +187,7 @@ def read_pose_csv_trajectory(file_path):
     :return: trajectory.PoseTrajectory3D object
     """
     mat = np.array(csv_read_matrix(
-        file_path, delim=",", comment_str="t")).astype(float)
+        file_path, delim=",", comment_str="#")).astype(float)
     if mat.shape[1] != 8:
         raise FileInterfaceException(
             "Pose trajectory files must have 8 entries per row")

--- a/evo/tools/file_interface.py
+++ b/evo/tools/file_interface.py
@@ -180,21 +180,20 @@ def read_euroc_csv_trajectory(file_path):
     return PoseTrajectory3D(xyz, quat, stamps)
 
 
-def read_swe_csv_trajectory(file_path):
+def read_pose_csv_trajectory(file_path):
     """
-    parses trajectory file in SWE format (timestamp[ns], x, y, z, qx, qy, qz, qw, vx, vy, vz, bgx, bgy, bgz, bax, bay, baz)
+    parses trajectory file in pose format (timestamp[ns], x, y, z, qw, qx, qy, qz)
     :param file_path: the trajectory file path (or file handle)
     :return: trajectory.PoseTrajectory3D object
     """
     mat = np.array(csv_read_matrix(
         file_path, delim=",", comment_str="t")).astype(float)
-    if mat.shape[1] != 17:
+    if mat.shape[1] != 8:
         raise FileInterfaceException(
-            "SWE trajectory files must have 8 entries per row")
+            "Pose trajectory files must have 8 entries per row")
     stamps = np.divide(mat[:, 0], 1e9)  # n x 1  -  nanoseconds to seconds
     xyz = mat[:, 1:4]  # n x 3
     quat = mat[:, 4:8]  # n x 4
-    quat = np.roll(quat, 1, axis=1)  # shift 1 column -> w in front column
     if not hasattr(file_path, 'read'):  # if not file handle
         logger.debug("Loaded {} stamps and poses from: {}".format(
             len(stamps), file_path))


### PR DESCRIPTION
- Change command-line evaluation of euroc results to use euroc-format csv's for both gt and estimated trajectories
- Remove `evo.tools.file_interface.read_swe_csv_trajectory` as it was redundant; we rely on the euroc version for 17-state trajectories
- Add `evo.tools.file_interface.read_pose_csv_trajectory`, which is an 8-state trajectory representation with timestamp, position and quaternion only (no velocity or angular rates)